### PR TITLE
Fix filepath errors for bio and favicon images

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,21 +22,21 @@
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/assets/favicon/apple-touch-icon.png"
+      href="assets/favicon/apple-touch-icon.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="/assets/favicon/favicon-32x32.png"
+      href="assets/favicon/favicon-32x32.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="16x16"
-      href="/assets/favicon/favicon-16x16.png"
+      href="assets/favicon/favicon-16x16.png"
     />
-    <link rel="manifest" href="/assets/favicon/site.webmanifest" />
+    <link rel="manifest" href="assets/favicon/site.webmanifest" />
   </head>
 
   <body>
@@ -86,7 +86,7 @@
                 </div>
                 <div class="col-12 col-md-6 col-lg-4">
                     <div class="card mb-3 sharp-corners">
-                        <img src="/assets/images/team/damir-bio.png" class="card-img-top fixed-image" alt="">
+                        <img src="assets/images/team/damir-bio.png" class="card-img-top fixed-image" alt="">
                         <div class="card-body">
                             <h3 class="card-title">Damir</h3>
                             <p class="card-text">Scrum Lead and Development

--- a/index.html
+++ b/index.html
@@ -22,21 +22,21 @@
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/assets/favicon/apple-touch-icon.png"
+      href="assets/favicon/apple-touch-icon.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="/assets/favicon/favicon-32x32.png"
+      href="assets/favicon/favicon-32x32.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="16x16"
-      href="/assets/favicon/favicon-16x16.png"
+      href="assets/favicon/favicon-16x16.png"
     />
-    <link rel="manifest" href="/assets/favicon/site.webmanifest" />
+    <link rel="manifest" href="assets/favicon/site.webmanifest" />
   </head>
 
   <body>


### PR DESCRIPTION
Removed the '/' before 'assets' to attempt fixing the image errors on deployed site